### PR TITLE
PLATFORM-4900: Update README and General Code Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,7 @@ $ git submodule add https://github.com/pokitdok/pokitdok-swift.git
 
 - Select the top `pokitdok.framework` and add it.
 
-## Use
-
-### Calling Eligibility
-
+## Quick Start
 ```swift
 import pokitdok
 
@@ -63,3 +60,75 @@ let elig_args = [
         
 let elig_response = try client.eligibility(eligibilityRequest: elig_args)
 ```
+## Making Requests
+
+The client offers a few options for making API requests. High level functions are available for each of the APIs for convenience. If your application would prefer to interact with the APIs at a lower level, you may elect to use the general purpose request method or one of the http method aliases built around it.
+
+```swift
+// A low level "request" method is available
+let act_response = try client.request(path: "/activities", method: "GET")
+
+let elig_args = [
+    "member": [
+        "birth_date" : "1970-01-25",
+        "first_name" : "Jane",
+        "last_name" : "Doe",
+        "id": "W000000000"
+    ],
+    "provider": [
+        "first_name" : "JEROME",
+        "last_name" : "AYA-AY",
+        "npi" : "1467560003"
+    ],
+    "trading_partner_id": "MOCKPAYER"
+] as [String : Any]
+let elig_response = try client.request(path: "/eligibility/", method: "POST", params: elig_args)
+
+// Convenience methods are available for the commonly used http methods built around the request method
+let act_response = try client.get(path: "/activities")
+
+let elig_args = [
+    "member": [
+        "birth_date" : "1970-01-25",
+        "first_name" : "Jane",
+        "last_name" : "Doe",
+        "id": "W000000000"
+    ],
+    "provider": [
+        "first_name" : "JEROME",
+        "last_name" : "AYA-AY",
+        "npi" : "1467560003"
+    ],
+    "trading_partner_id": "MOCKPAYER"
+] as [String : Any]
+let elig_response = try client.post(path: "/eligibility/", params: elig_args)
+
+// Higher level functions are also available to access the APIs
+let act_response = try client.activities()
+
+let elig_args = [
+    "member": [
+        "birth_date" : "1970-01-25",
+        "first_name" : "Jane",
+        "last_name" : "Doe",
+        "id": "W000000000"
+    ],
+    "provider": [
+        "first_name" : "JEROME",
+        "last_name" : "AYA-AY",
+        "npi" : "1467560003"
+    ],
+    "trading_partner_id": "MOCKPAYER"
+] as [String : Any]
+let elig_response = try client.eligibility(eligibilityRequest: elig_args)
+```
+## Authentication
+Access to PokitDok APIs is controlled via OAuth2. Most APIs are accessible with an access token acquired via a client credentials grant type, you simply supply your app credentials and you're ready to go:
+```swift
+import pokitdok
+
+let client_id = "<your-client-id>"
+let client_secret = "<your-client-secret>"
+let client = try Pokitdok(clientId: client_id, clientSecret: client_secret)
+```
+*Sidenote*: It is highly recommended that you do not release an iOS app with your Client ID and Client Secret strings baked into the app, as they may be vulnerable to exposure there. A suitable alternative would be to utilize an external identity service that authenticates your users and requests an access token that can then be returned to your app to utilize.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ let elig_args = [
     "trading_partner_id": "MOCKPAYER"
 ] as [String : Any]
         
-let elig_response = try client.eligibility(eligibilityRequest: elig_args)
+let elig_response = try client.eligibility(params: elig_args)
 ```
 ## Making Requests
 
@@ -120,7 +120,7 @@ let elig_args = [
     ],
     "trading_partner_id": "MOCKPAYER"
 ] as [String : Any]
-let elig_response = try client.eligibility(eligibilityRequest: elig_args)
+let elig_response = try client.eligibility(params: elig_args)
 ```
 ## Authentication
 Access to PokitDok APIs is controlled via OAuth2. Most APIs are accessible with an access token acquired via a client credentials grant type, you simply supply your app credentials and you're ready to go:

--- a/pokitdok.xcodeproj/project.pbxproj
+++ b/pokitdok.xcodeproj/project.pbxproj
@@ -12,6 +12,10 @@
 		1D18584E1DCD1445005D573B /* pokitdok.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D1858401DCD1444005D573B /* pokitdok.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1D1858581DCD1488005D573B /* Pokitdok.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1858571DCD1488005D573B /* Pokitdok.swift */; };
 		1D18585A1DCD14A2005D573B /* PokitdokRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1858591DCD14A2005D573B /* PokitdokRequest.swift */; };
+		1D1859031DD38CA4005D573B /* testingResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1859021DD38CA4005D573B /* testingResources.swift */; };
+		1D1859051DD3B493005D573B /* PokitdokResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1859041DD3B493005D573B /* PokitdokResponse.swift */; };
+		1D1859071DD3B4EE005D573B /* FileData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1859061DD3B4EE005D573B /* FileData.swift */; };
+		1D1859091DD3B551005D573B /* PokitdokErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1859081DD3B551005D573B /* PokitdokErrors.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -33,6 +37,10 @@
 		1D18584D1DCD1445005D573B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1D1858571DCD1488005D573B /* Pokitdok.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pokitdok.swift; sourceTree = "<group>"; };
 		1D1858591DCD14A2005D573B /* PokitdokRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PokitdokRequest.swift; sourceTree = "<group>"; };
+		1D1859021DD38CA4005D573B /* testingResources.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = testingResources.swift; sourceTree = "<group>"; };
+		1D1859041DD3B493005D573B /* PokitdokResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PokitdokResponse.swift; sourceTree = "<group>"; };
+		1D1859061DD3B4EE005D573B /* FileData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileData.swift; sourceTree = "<group>"; };
+		1D1859081DD3B551005D573B /* PokitdokErrors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PokitdokErrors.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -79,6 +87,9 @@
 				1D1858411DCD1444005D573B /* Info.plist */,
 				1D1858571DCD1488005D573B /* Pokitdok.swift */,
 				1D1858591DCD14A2005D573B /* PokitdokRequest.swift */,
+				1D1859041DD3B493005D573B /* PokitdokResponse.swift */,
+				1D1859061DD3B4EE005D573B /* FileData.swift */,
+				1D1859081DD3B551005D573B /* PokitdokErrors.swift */,
 			);
 			path = pokitdok;
 			sourceTree = "<group>";
@@ -88,6 +99,7 @@
 			children = (
 				1D18584B1DCD1445005D573B /* pokitdokTests.swift */,
 				1D18584D1DCD1445005D573B /* Info.plist */,
+				1D1859021DD38CA4005D573B /* testingResources.swift */,
 			);
 			path = pokitdokTests;
 			sourceTree = "<group>";
@@ -204,7 +216,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				1D18585A1DCD14A2005D573B /* PokitdokRequest.swift in Sources */,
+				1D1859051DD3B493005D573B /* PokitdokResponse.swift in Sources */,
+				1D1859091DD3B551005D573B /* PokitdokErrors.swift in Sources */,
 				1D1858581DCD1488005D573B /* Pokitdok.swift in Sources */,
+				1D1859071DD3B4EE005D573B /* FileData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -212,6 +227,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1D1859031DD38CA4005D573B /* testingResources.swift in Sources */,
 				1D18584C1DCD1445005D573B /* pokitdokTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/pokitdok/FileData.swift
+++ b/pokitdok/FileData.swift
@@ -1,0 +1,38 @@
+//
+//  FileData.swift
+//  pokitdok
+//
+// Copyright (C) 2016, All Rights Reserved, PokitDok, Inc.
+// https://www.pokitdok.com
+//
+// Please see the License.txt file for more information.
+// All other rights reserved.
+//
+
+public struct FileData {
+    /*
+     struct to hold file information for transmission
+     :VAR path: The file structure path to the file
+     :VAR contentType: The content type to be transmitted with the file
+     */
+    var path: String
+    var contentType: String
+
+    public func httpEncode() throws -> Data{
+        /*
+         Encodes file into data for http transmission
+         :RETURNS body: Data type filled with content headers and file data
+         */
+        var body = Data()
+        do {
+            let url = URL(fileURLWithPath: self.path)
+            body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(url.lastPathComponent)\"\r\n".data(using: .utf8)!)
+            body.append("Content-Type: \(self.contentType)\r\n\r\n".data(using: .utf8)!)
+            body.append(try Data(contentsOf: url))
+            body.append("\r\n".data(using: .utf8)!)
+        } catch {
+            throw DataConversionError.FileEncoding("Failed to encode File for http request")
+        }
+        return body
+    }
+}

--- a/pokitdok/Pokitdok.swift
+++ b/pokitdok/Pokitdok.swift
@@ -72,14 +72,14 @@ public class Pokitdok: NSObject {
         if username == nil || password == nil {
             throw FailedToFetchTokenError.CouldNotAuthenticate("Client ID and Client Secret are required to fetch an access token")
         }
-
         let utf8str = "\(username!):\(password!)".data(using: String.Encoding.utf8)
         let encodedIdSecret = utf8str?.base64EncodedString(options: [])
         let headers = ["Authorization" : "Basic \(encodedIdSecret ?? "")", "Content-Type" : "application/x-www-form-urlencoded"] as Dictionary<String, String>
         let params = ["grant_type" : "client_credentials"] as Dictionary<String, Any>
-        
-        let tokenResponse = try PokitdokRequest(path: tokenUrl, method: "POST", headers: headers, params: params).call()
-        
+
+        let tokenRequest = try PokitdokRequest(path: tokenUrl, method: "POST", headers: headers, params: params)
+        let tokenResponse = try tokenRequest.call()
+
         if tokenResponse.success == true {
             self.accessToken = tokenResponse.json?["access_token"] as! String?
         } else {
@@ -157,31 +157,31 @@ public class Pokitdok: NSObject {
         return try request(path: path, method: "DELETE", params: params)
     }
     
-    public func activities(activityId: String? = nil, activitiesRequest: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
+    public func activities(activityId: String? = nil, params: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
         /*
          Fetch platform activity information
          :PARAM activityId: String type activity ID
-         :PARAM activitiesRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/activities/\(activityId ?? "")"
         let method = "GET"
         
-        return try request(path: path, method: method, params: activitiesRequest)
+        return try request(path: path, method: method, params: params)
     }
     
-    public func authorizations(authorizationsRequest: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
+    public func authorizations(params: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
         /*
          Submit an authorization request
-         :PARAM authorizationsRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/authorizations/"
         let method = "POST"
         
-        return try request(path: path, method: method, params: authorizationsRequest)
+        return try request(path: path, method: method, params: params)
     }
     
     public func cashPrices(cptCode: String, zipCode: String) throws -> Dictionary<String, Any> {
@@ -199,43 +199,43 @@ public class Pokitdok: NSObject {
         return try request(path: path, method: method, params: cashPricesRequest)
     }
     
-    public func ccd(ccdRequest: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
+    public func ccd(params: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
         /*
          Submit a continuity of care document (CCD) request
-         :PARAM ccdRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/ccd/"
         let method = "POST"
         
-        return try request(path: path, method: method, params: ccdRequest)
+        return try request(path: path, method: method, params: params)
     }
     
-    public func claims(claimsRequest: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
+    public func claims(params: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
         /*
          Submit a claims request
-         :PARAM claimsRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/claims/"
         let method = "POST"
         
-        return try request(path: path, method: method, params: claimsRequest)
+        return try request(path: path, method: method, params: params)
     }
     
-    public func claimsStatus(claimsStatusRequest: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
+    public func claimsStatus(params: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
         /*
          Submit a claims status request
-         :PARAM claimsStatusRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/claims/status"
         let method = "POST"
         
-        return try request(path: path, method: method, params: claimsStatusRequest)
+        return try request(path: path, method: method, params: params)
     }
     
     public func claimsConvert(x12ClaimsFilePath: String) throws -> Dictionary<String, Any> {
@@ -252,30 +252,30 @@ public class Pokitdok: NSObject {
         return try request(path: path, method: method, files: [file])
     }
     
-    public func eligibility(eligibilityRequest: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
+    public func eligibility(params: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
         /*
          Submit an eligibility request
-         :PARAM eligibilityRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/eligibility/"
         let method = "POST"
         
-        return try request(path: path, method: method, params: eligibilityRequest)
+        return try request(path: path, method: method, params: params)
     }
     
-    public func enrollment(enrollmentRequest: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
+    public func enrollment(params: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
         /*
          Submit a benefits enrollment/maintenance request
-         :PARAM enrollmentRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/enrollment"
         let method = "POST"
         
-        return try request(path: path, method: method, params: enrollmentRequest)
+        return try request(path: path, method: method, params: params)
     }
     
     public func enrollmentSnapshot(tradingPartnerId: String, x12FilePath: String) throws -> Dictionary<String, Any> {
@@ -295,18 +295,18 @@ public class Pokitdok: NSObject {
         return try request(path: path, method: method, params: params, files: [file])
     }
     
-    public func enrollmentSnapshots(snapshotId: String? = nil, snapshotsRequest: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
+    public func enrollmentSnapshots(snapshotId: String? = nil, params: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
         /*
          List enrollment snapshots that are stored for the client application
          :PARAM snapshotId: String? type id of snapshot
-         :PARAM snapshotsRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/enrollment/snapshot/\(snapshotId ?? "")"
         let method = "GET"
         
-        return try request(path: path, method: method, params: snapshotsRequest)
+        return try request(path: path, method: method, params: params)
     }
     
     public func enrollmentSnapshotData(snapshotId: String) throws -> Dictionary<String, Any> {
@@ -368,68 +368,68 @@ public class Pokitdok: NSObject {
         return try request(path: path, method: method, params: mpcRequest)
     }
     
-    public func oopLoadPrice(oopLoadPriceRequest: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
+    public func oopLoadPrice(params: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
         /*
          Load pricing data to OOP endpoint
-         :PARAM oopLoadPriceRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         let path = "/oop/insurance-load-price"
         let method = "POST"
         
-        return try request(path: path, method: method, params: oopLoadPriceRequest)
+        return try request(path: path, method: method, params: params)
     }
     
-    public func oopEstimate(oopEstimateRequest: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
+    public func oopEstimate(params: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
         /*
          Fetch OOP estimate
-         :PARAM oopEstimateRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         let path = "/oop/insurance-estimate"
         let method = "POST"
         
-        return try request(path: path, method: method, params: oopEstimateRequest)
+        return try request(path: path, method: method, params: params)
     }
     
-    public func payers(payersRequest: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
+    public func payers(params: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
         /*
          Fetch payer information for supported trading partners
-         :PARAM payersRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/payers/"
         let method = "GET"
         
-        return try request(path: path, method: method, params: payersRequest)
+        return try request(path: path, method: method, params: params)
     }
     
-    public func plans(plansRequest: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
+    public func plans(params: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
         /*
          Fetch insurance plans information
-         :PARAM plansRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/plans"
         let method = "GET"
         
-        return try request(path: path, method: method, params: plansRequest)
+        return try request(path: path, method: method, params: params)
     }
     
-    public func providers(npi: String? = nil, providersRequest: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
+    public func providers(npi: String? = nil, params: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
         /*
          Search health care providers in the PokitDok directory
          :PARAM npi: String? type npi to search on
-         :PARAM providersRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/providers/\(npi ?? "")"
         let method = "GET"
         
-        return try request(path: path, method: method, params: providersRequest)
+        return try request(path: path, method: method, params: params)
     }
     
     public func tradingPartners(tradingPartnerId: String? = nil) throws -> Dictionary<String, Any> {
@@ -445,17 +445,17 @@ public class Pokitdok: NSObject {
         return try request(path: path, method: method)
     }
     
-    public func referrals(referralRequest: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
+    public func referrals(params: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
         /*
          Submit a referral request
-         :PARAM referralRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/referrals/"
         let method = "POST"
         
-        return try request(path: path, method: method, params: referralRequest)
+        return try request(path: path, method: method, params: params)
     }
     
     public func schedulers(schedulerUuid: String? = nil) throws -> Dictionary<String, Any> {
@@ -484,59 +484,59 @@ public class Pokitdok: NSObject {
         return try request(path: path, method: method)
     }
     
-    public func scheduleSlots(slotsRequest: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
+    public func scheduleSlots(params: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
         /*
          Submit an open slot for a provider's schedule
-         :PARAM slotsRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/schedule/slots/"
         let method = "POST"
         
-        return try request(path: path, method: method, params: slotsRequest)
+        return try request(path: path, method: method, params: params)
     }
     
-    public func appointments(appointmentUuid: String? = nil, appointmentsRequest: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
+    public func appointments(appointmentUuid: String? = nil, params: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
         /*
          Query for open appointment slots or retrieve information for a specific appointment
          :PARAM appointmentUuid: String? type uuid of appointment to fetch
-         :PARAM appointmentsRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/schedule/appointments/\(appointmentUuid ?? "")"
         let method = "GET"
         
-        return try request(path: path, method: method, params: appointmentsRequest)
+        return try request(path: path, method: method, params: params)
     }
     
-    public func bookAppointment(appointmentUuid: String, appointmentRequest: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
+    public func bookAppointment(appointmentUuid: String, params: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
         /*
          Book an appointment
          :PARAM appointmentUuid: String type uuid of appointment to book
-         :PARAM appointmentRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/schedule/appointments/\(appointmentUuid)"
         let method = "PUT"
         
-        return try request(path: path, method: method, params: appointmentRequest)
+        return try request(path: path, method: method, params: params)
     }
     
-    public func updateAppointment(appointmentUuid: String, appointmentRequest: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
+    public func updateAppointment(appointmentUuid: String, params: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
         /*
          Update an appointment
          :PARAM appointmentUuid: String type uuid of appointment to update
-         :PARAM appointmentRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/schedule/appointments/\(appointmentUuid)"
         let method = "PUT"
         
-        return try request(path: path, method: method, params: appointmentRequest)
+        return try request(path: path, method: method, params: params)
     }
     
     public func cancelAppointment(appointmentUuid: String) throws -> Dictionary<String, Any> {
@@ -552,45 +552,45 @@ public class Pokitdok: NSObject {
         return try request(path: path, method: method)
     }
     
-    public func createIdentity(identityRequest: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
+    public func createIdentity(params: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
         /*
          Creates an identity resource
-         :PARAM identityRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/identity/"
         let method = "POST"
         
-        return try request(path: path, method: method, params: identityRequest)
+        return try request(path: path, method: method, params: params)
     }
     
-    public func updateIdentity(identityUuid: String, identityRequest: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
+    public func updateIdentity(identityUuid: String, params: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
         /*
          Updates an existing identity resource.
          :PARAM identityUuid: String type uuid of identity to update
-         :PARAM identityRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/identity/\(identityUuid)"
         let method = "PUT"
         
-        return try request(path: path, method: method, params: identityRequest)
+        return try request(path: path, method: method, params: params)
     }
     
-    public func identity(identityUuid: String? = nil, identityRequest: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
+    public func identity(identityUuid: String? = nil, params: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
         /*
          Queries for an existing identity resource by uuid or for multiple resources using parameters.
          :PARAM identityUuid: String? type uuid of identity to fetch
-         :PARAM identityRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/identity/\(identityUuid ?? "")"
         let method = "GET"
         
-        return try request(path: path, method: method, params: identityRequest)
+        return try request(path: path, method: method, params: params)
     }
     
     public func identityHistory(identityUuid: String, historicalVersion: String? = nil) throws -> Dictionary<String, Any> {
@@ -607,57 +607,57 @@ public class Pokitdok: NSObject {
         return try request(path: path, method: method)
     }
     
-    public func identityMatch(identityMatchData: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
+    public func identityMatch(params: Dictionary<String, Any>) throws -> Dictionary<String, Any> {
         /*
          Creates an identity match job.
-         :PARAM identityMatchData: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/identity/match"
         let method = "POST"
         
-        return try request(path: path, method: method, params: identityMatchData)
+        return try request(path: path, method: method, params: params)
     }
     
-    public func pharmacyPlans(pharmacyPlansRequest: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
+    public func pharmacyPlans(params: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
         /*
          Search drug plan information by trading partner and various plan identifiers
-         :PARAM pharmacyPlansRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/pharmacy/plans"
         let method = "GET"
         
-        return try request(path: path, method: method, params: pharmacyPlansRequest)
+        return try request(path: path, method: method, params: params)
     }
     
-    public func pharmacyFormulary(pharmacyFormularyRequest: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
+    public func pharmacyFormulary(params: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
         /*
          Search drug plan formulary information to determine if a drug is covered by the specified drug plan.
-         :PARAM pharmacyFormularyRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/pharmacy/formulary"
         let method = "GET"
         
-        return try request(path: path, method: method, params: pharmacyFormularyRequest)
+        return try request(path: path, method: method, params: params)
     }
     
-    public func pharmacyNetwork(npi: String? = nil, pharmacyNetworkRequest: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
+    public func pharmacyNetwork(npi: String? = nil, params: Dictionary<String, Any>? = nil) throws -> Dictionary<String, Any> {
         /*
          Search for in-network pharmacies
          :PARAM npi: String? type npi to search on
-         :PARAM pharmacyNetworkRequest: [String:Any] type parameters to be sent along with request
+         :PARAM params: [String:Any] type parameters to be sent along with request
          :RETURNS json: [String:Any] type key:value response from server after request
          */
         
         let path = "/pharmacy/network/\(npi ?? "")"
         let method = "GET"
         
-        return try request(path: path, method: method, params: pharmacyNetworkRequest)
+        return try request(path: path, method: method, params: params)
     }
     
 }

--- a/pokitdok/Pokitdok.swift
+++ b/pokitdok/Pokitdok.swift
@@ -11,20 +11,13 @@
 
 import Foundation
 
-public enum FailedToFetchTokenError : Error {
-    /*
-        Custom error handling to track client requests
-    */
-    case CouldNotAuthenticate(String)
-}
-
 public class Pokitdok: NSObject {
     /*
      Pokitdok Swift client convenient to send requests to Pokitdok Platform APIs
      */
     
-    let username: String
-    let password: String
+    let username: String?
+    let password: String?
     let urlBase: String
     let tokenUrl: String
     let authUrl: String
@@ -35,13 +28,13 @@ public class Pokitdok: NSObject {
     let authCode: String?
     var accessToken: String? = nil
     
-    public init(clientId: String, clientSecret: String, basePath: String = "https://platform.pokitdok.com", version: String = "v4",
+    public init(clientId: String? = nil, clientSecret: String? = nil, basePath: String = "https://platform.pokitdok.com", version: String = "v4",
          redirectUri: String? = nil, scope: String? = nil, autoRefresh: Bool = false, tokenRefreshCallback: String? = nil,
          code: String? = nil, token: String? = nil) throws {
         /*
          Initialize necessary variables
-         :PARAM clientId: String type client ID for OAuth client credentials flow
-         :PARAM clientSecret: String type client secret for OAuth client credentials flow
+         :PARAM clientId: String? type client ID for OAuth client credentials flow
+         :PARAM clientSecret: String? type client secret for OAuth client credentials flow
          :PARAM basePath: String type url path that other urls will be based off
          :PARAM version: String type version of api, defaulted to "v4"
          :PARAM redirectUri: String? type redirect path used to authorize via Oauth authorization grant flow
@@ -65,6 +58,7 @@ public class Pokitdok: NSObject {
         accessToken = token
         
         super.init()
+
         if accessToken == nil{
             try fetchAccessToken()
         }
@@ -75,7 +69,11 @@ public class Pokitdok: NSObject {
          Retrieve OAuth2 access token and set it on self.accessToken
          */
         
-        let utf8str = "\(username):\(password)".data(using: String.Encoding.utf8)
+        if username == nil || password == nil {
+            throw FailedToFetchTokenError.CouldNotAuthenticate("Client ID and Client Secret are required to fetch an access token")
+        }
+
+        let utf8str = "\(username!):\(password!)".data(using: String.Encoding.utf8)
         let encodedIdSecret = utf8str?.base64EncodedString(options: [])
         let headers = ["Authorization" : "Basic \(encodedIdSecret ?? "")", "Content-Type" : "application/x-www-form-urlencoded"] as Dictionary<String, String>
         let params = ["grant_type" : "client_credentials"] as Dictionary<String, Any>

--- a/pokitdok/PokitdokErrors.swift
+++ b/pokitdok/PokitdokErrors.swift
@@ -1,0 +1,26 @@
+//
+//  PokitdokErrors.swift
+//  pokitdok
+//
+// Copyright (C) 2016, All Rights Reserved, PokitDok, Inc.
+// https://www.pokitdok.com
+//
+// Please see the License.txt file for more information.
+// All other rights reserved.
+//
+
+public enum DataConversionError: Error {
+    /*
+     Custom request error handling that tracks failures to convert data formats
+     */
+    case FromJSON(String)
+    case ToJSON(String)
+    case FileEncoding(String)
+}
+
+public enum FailedToFetchTokenError : Error {
+    /*
+     Custom error handling to track client requests that fail to fetch an access token
+     */
+    case CouldNotAuthenticate(String)
+}

--- a/pokitdok/PokitdokRequest.swift
+++ b/pokitdok/PokitdokRequest.swift
@@ -11,24 +11,6 @@
 
 import Foundation
 
-public struct PokitdokResponse {
-    /*
-     Struct to hold response information
-     :VAR success: Bool? type true or false success of the request
-     :VAR response: URLResponse? type response object from server
-     :VAR data: Data? type data of the response
-     :VAR error: Error? type errors from server
-     :VAR json: [String:Any]? type json data translated from response
-     :VAR message: String? type conveying messages about response ex(TOKEN_EXPIRED)
-     */
-    var success: Bool? = false
-    var response: URLResponse? = nil
-    var data: Data? = nil
-    var error: Error? = nil
-    var json: Dictionary<String, Any>? = nil
-    var message: String? = nil
-}
-
 public class PokitdokRequest: NSObject {
     /*
      Class to facilitate a single HTTP request and the resulting response
@@ -83,7 +65,7 @@ public class PokitdokRequest: NSObject {
         
         if let data = responseObject.data {
             do {
-                responseObject.json = try JSONSerialization.jsonObject(with: data, options: .mutableLeaves) as! Dictionary<String, Any>
+                responseObject.json = try JSONSerialization.jsonObject(with: data, options: .mutableLeaves) as? Dictionary<String, Any>
             } catch {
                 throw DataConversionError.FromJSON("Failed to parse JSON from data")
             }
@@ -131,7 +113,7 @@ public class PokitdokRequest: NSObject {
                     let contentType = getHeader(key: "Content-Type")
                     if contentType == "application/json" {
                         do {
-                            body = try! JSONSerialization.data(withJSONObject: params, options: [])
+                            body = try JSONSerialization.data(withJSONObject: params, options: [])
                         } catch {
                             throw DataConversionError.ToJSON("Failed to convert params to JSON")
                         }
@@ -236,41 +218,4 @@ public class PokitdokRequest: NSObject {
          */
         requestObject.httpBody = data
     }
-}
-
-public struct FileData {
-    /*
-     struct to hold file information for transmission
-     :VAR path: The file structure path to the file
-     :VAR contentType: The content type to be transmitted with the file
-     */
-    var path: String
-    var contentType: String
-    
-    public func httpEncode() throws -> Data{
-        /*
-         Encodes file into data for http transmission
-         :RETURNS body: Data type filled with content headers and file data
-         */
-        var body = Data()
-        do {
-            let url = URL(fileURLWithPath: self.path)
-            body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(url.lastPathComponent)\"\r\n".data(using: .utf8)!)
-            body.append("Content-Type: \(self.contentType)\r\n\r\n".data(using: .utf8)!)
-            body.append(try Data(contentsOf: url))
-            body.append("\r\n".data(using: .utf8)!)
-        } catch {
-            throw DataConversionError.FileEncoding("Failed to encode File for http request")
-        }
-        return body
-    }
-}
-
-public enum DataConversionError: Error {
-    /*
-        Custom request error handling
-    */
-    case FromJSON(String)
-    case ToJSON(String)
-    case FileEncoding(String)
 }

--- a/pokitdok/PokitdokResponse.swift
+++ b/pokitdok/PokitdokResponse.swift
@@ -1,0 +1,28 @@
+//
+//  PokitdokResponse.swift
+//  pokitdok
+//
+// Copyright (C) 2016, All Rights Reserved, PokitDok, Inc.
+// https://www.pokitdok.com
+//
+// Please see the License.txt file for more information.
+// All other rights reserved.
+//
+
+public struct PokitdokResponse {
+    /*
+     Struct to hold response information
+     :VAR success: Bool? type true or false success of the request
+     :VAR response: URLResponse? type response object from server
+     :VAR data: Data? type data of the response
+     :VAR error: Error? type errors from server
+     :VAR json: [String:Any]? type json data translated from response
+     :VAR message: String? type conveying messages about response ex(TOKEN_EXPIRED)
+     */
+    var success: Bool? = false
+    var response: URLResponse? = nil
+    var data: Data? = nil
+    var error: Error? = nil
+    var json: Dictionary<String, Any>? = nil
+    var message: String? = nil
+}

--- a/pokitdokTests/pokitdokTests.swift
+++ b/pokitdokTests/pokitdokTests.swift
@@ -41,6 +41,22 @@ class pokitdokTests: XCTestCase {
         XCTAssert(client.accessToken == token)
     }
     
+    func testMissingIdSecretThrowsFailedToFetchTokenError() throws {
+        /*
+         Test init of Pokitdok class without necessary variables
+         */
+
+        let base = "http://localhost:5002"
+        let version = "v4"
+        let redirect = "http://nowhere"
+        let scope = "myScope"
+        let tokenCallback = "callback"
+        let code = "007"
+        XCTAssertThrows(error: FailedToFetchTokenError.CouldNotAuthenticate(""), block: {
+            _ = try Pokitdok(basePath: base, version: version, redirectUri: redirect, scope: scope, autoRefresh: true, tokenRefreshCallback: tokenCallback, code: code)
+        })
+    }
+
     func testPokitdokResponse() {
         /*
          Test default values of PokitdokResponse struct
@@ -122,5 +138,4 @@ class pokitdokTests: XCTestCase {
         XCTAssert(request.getHeader(key: "Content-Type") == "application/x-www-form-urlencoded")
         XCTAssert(request.getBody() == "trading_partner_id=MOCKPAYER".data(using: .utf8))
     }
-    
 }

--- a/pokitdokTests/testingResources.swift
+++ b/pokitdokTests/testingResources.swift
@@ -1,0 +1,38 @@
+//
+//  testingResources.swift
+//  pokitdokTests
+//
+// Copyright (C) 2016, All Rights Reserved, PokitDok, Inc.
+// https://www.pokitdok.com
+//
+// Please see the License.txt file for more information.
+// All other rights reserved.
+//
+
+import XCTest
+
+public func throwsError(error: Error, block: () throws -> ()) -> Bool{
+    /*
+        Method to test that error is thrown when block is executed
+        :PARAM error: error to test has occurred
+        :PARAM block: code block to execute
+        :RETURNS bool: true if expected error occurs
+    */
+    do {
+        try block()
+    }
+    catch let e as Error {
+        if type(of: e) == type(of: error) {
+            return true
+        }
+        return false
+    }
+    return false
+}
+
+public func XCTAssertThrows(error: Error, block: () throws -> ()) {
+    /*
+        Method to assert that specific error is thrown
+    */
+    XCTAssert(throwsError(error: error, block: block))
+}


### PR DESCRIPTION
A few things here:

- Updating the README to look like the pokitdok-python readme (more info)
- Giving each class or struct its own file to live in for organizational purposes
- Make client id / secret optional fields so that users can pass in just an access token and still operate + added test
- Converting all those funky request arg names in the convenience methods to be called `params` for simplicity