### PR TITLE
EV-57: Add User-Agent to headers, status_code variable

### DIFF
--- a/pokitdok/PokitdokRequest.swift
+++ b/pokitdok/PokitdokRequest.swift
@@ -51,8 +51,9 @@ public class PokitdokRequest: NSObject {
             self.responseObject.response = response
             self.responseObject.data = data
             self.responseObject.error = error
-            
+
             if let response = response as? HTTPURLResponse {
+                self.responseObject.status = response.statusCode
                 if 200...299 ~= response.statusCode {
                     self.responseObject.success = true
                 } else if 401 ~= response.statusCode {

--- a/pokitdok/PokitdokResponse.swift
+++ b/pokitdok/PokitdokResponse.swift
@@ -25,4 +25,5 @@ public struct PokitdokResponse {
     var error: Error? = nil
     var json: Dictionary<String, Any>? = nil
     var message: String? = nil
+    var status: Int? = nil
 }

--- a/pokitdokTests/pokitdokTests.swift
+++ b/pokitdokTests/pokitdokTests.swift
@@ -39,6 +39,7 @@ class pokitdokTests: XCTestCase {
         XCTAssert(client.tokenCallback == tokenCallback)
         XCTAssert(client.authCode == code)
         XCTAssert(client.accessToken == token)
+        XCTAssert(client.status_code == nil)
     }
     
     func testMissingIdSecretThrowsFailedToFetchTokenError() throws {


### PR DESCRIPTION
https://pokitdok.atlassian.net/browse/EV-57

Adds User-Agent to the request headers and public status code variable that is set after each request.